### PR TITLE
docs: edit pkgdown config to not lose search bar

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,4 +1,4 @@
-url: https://docs.ropensci.org/tsbox/dev
+url: https://docs.ropensci.org/tsbox/
 
 template:
   bootstrap: 5
@@ -101,23 +101,3 @@ reference:
   contents:
   - tsbox-defunct
   - tsbox-package
-
-navbar:
-  title: ~
-  type: default
-  left:
-  - text: Intro
-    href: articles/tsbox.html
-  - text: Reference
-    href: reference/index.html
-  - text: Advanced
-    menu:
-    - text: User Defined ts-Functions
-      href: articles/ts-functions.html
-    - text: Time Conversion and Reguarization
-      href: articles/convert.html
-  - text: News
-    href: news/index.html
-  right:
-  - icon: fa-github fa-lg
-    href: https://github.com/ropensci/tsbox


### PR DESCRIPTION
:wave: @christophsax!

- fixing the URL (the rOpenSci docs building system does not support dev mode at the moment)
- I removed the navbar related config. Compared to the default https://pkgdown.r-lib.org/articles/customise.html#navbar-heading the config only meant calling the articles section "Advanced". With the current config, and the new pkgdown version we're about to use in the system, you'd lose the search bar.

If you prefer I can tweak the config so "Articles" keep getting shown under "Advanced".